### PR TITLE
Update Help.vue with new links

### DIFF
--- a/web_interface_vue/tamagometer/src/components/Help.vue
+++ b/web_interface_vue/tamagometer/src/components/Help.vue
@@ -57,8 +57,9 @@ function retry() {
                     target="_blank">Tamagometer Companion app</a>, and make sure it is open on your Flipper.</p>
             <p>Note: the Flipper's screen does not change based on whether it is connected to the tamagometer. As
                 long as the app is open, it is waiting for commands in the background.</p>
+            <p>See <a href="https://github.com/zacharesmer/tamagometer?tab=readme-ov-file#flipper-zero" target="_blank">here</a> for more details.</p>
             <h3>DIY device Setup (Raspberry Pi Pico or other)</h3>
-            <p><a href="https://github.com/zacharesmer/tamagometer?tab=readme-ov-file#hardware" target="_blank">Follow
+            <p><a href="https://github.com/zacharesmer/tamagometer?tab=readme-ov-file#diybring-your-own-board" target="_blank">Follow
                     the instructions here</a> to connect the infrared receiver and transmitter, and load the
                 firmware onto the board.</p>
             <h2>Demo: Test it out!</h2>

--- a/web_interface_vue/tamagometer/src/components/Help.vue
+++ b/web_interface_vue/tamagometer/src/components/Help.vue
@@ -57,7 +57,7 @@ function retry() {
                     target="_blank">Tamagometer Companion app</a>, and make sure it is open on your Flipper.</p>
             <p>Note: the Flipper's screen does not change based on whether it is connected to the tamagometer. As
                 long as the app is open, it is waiting for commands in the background.</p>
-            <p>See <a href="https://github.com/zacharesmer/tamagometer?tab=readme-ov-file#flipper-zero" target="_blank">here</a> for more details.</p>
+            <p>See <a href="https://github.com/zacharesmer/tamagometer?tab=readme-ov-file#flipper-zero" target="_blank">the readme</a> for more details.</p>
             <h3>DIY device Setup (Raspberry Pi Pico or other)</h3>
             <p><a href="https://github.com/zacharesmer/tamagometer?tab=readme-ov-file#diybring-your-own-board" target="_blank">Follow
                     the instructions here</a> to connect the infrared receiver and transmitter, and load the


### PR DESCRIPTION
- Make the DIY device setup section link to the specific section of the README (I think that section just didn't exist at the time the Help.vue file was created)
- Add a link to the Flipper Zero section of the README in the Flipper hardware setup section

I left the overall instructions layout the same, just updated the DIY device link and added one for the Flipper Zero. Feel free to make any wording/etc edits!